### PR TITLE
Add unit tests for cams_call.py controller

### DIFF
--- a/navari_cams_biometric/cams_biometric/controllers/test_cams_call.py
+++ b/navari_cams_biometric/cams_biometric/controllers/test_cams_call.py
@@ -1,14 +1,15 @@
 import json
-from unittest import TestCase
+from frappe.tests.utils import FrappeTestCase
 from unittest.mock import patch, MagicMock
 from navari_cams_biometric.cams_biometric.controllers.cams_call import (
     handle_attendance_log,
     handle_punch_logs,
     attendance,
+    update_last_sync_time,
 )
 
 
-class TestCamsCall(TestCase):
+class TestCamsCall(FrappeTestCase):
 
     @patch("navari_cams_biometric.cams_biometric.controllers.cams_call.frappe")
     @patch("navari_cams_biometric.cams_biometric.controllers.cams_call.parser")
@@ -123,4 +124,18 @@ class TestCamsCall(TestCase):
         self.assertEqual(response.status_code, 200)
         mock_handle_punch_logs.assert_called_once_with("STG001", data_punchlog["PunchLog"]["Log"])
 
+    @patch("navari_cams_biometric.cams_biometric.controllers.cams_call.frappe")
+    def test_update_last_sync_time_calls_db_methods(self, mock_frappe):
+        shift = "Shift A"
+        time = "2024-05-01 08:00:00"
 
+        mock_frappe.db.set_value = MagicMock()
+        mock_frappe.db.commit = MagicMock()
+
+        result = update_last_sync_time(shift, time)
+
+        mock_frappe.db.set_value.assert_called_once_with(
+            "Shift Type", shift, "last_sync_of_checkin", time, update_modified=False
+        )
+        mock_frappe.db.commit.assert_called_once()
+        self.assertEqual(result, "done")

--- a/navari_cams_biometric/cams_biometric/controllers/test_cams_call.py
+++ b/navari_cams_biometric/cams_biometric/controllers/test_cams_call.py
@@ -1,0 +1,126 @@
+import json
+from unittest import TestCase
+from unittest.mock import patch, MagicMock
+from navari_cams_biometric.cams_biometric.controllers.cams_call import (
+    handle_attendance_log,
+    handle_punch_logs,
+    attendance,
+)
+
+
+class TestCamsCall(TestCase):
+
+    @patch("navari_cams_biometric.cams_biometric.controllers.cams_call.frappe")
+    @patch("navari_cams_biometric.cams_biometric.controllers.cams_call.parser")
+    def test_handle_attendance_log_inserts_checkin(self, mock_parser, mock_frappe):
+        rawdata = '''
+        {
+            "RealTime": {
+                "PunchLog": {
+                    "Type": "CheckIn",
+                    "LogTime": "2024-05-01T08:00:00",
+                    "UserId": "EMP001",
+                    "InputType": "Fingerprint"
+                }
+            }
+        }
+        '''
+
+        mock_parser.parse.return_value.strftime.return_value = "2024-05-01 08:00:00"
+        mock_frappe.db.exists.return_value = None
+        mock_frappe.get_doc.return_value.insert.return_value = None
+        mock_frappe.db.commit = MagicMock()
+        mock_frappe.db.sql.return_value = [{"default_shift": "Shift A"}]
+
+        handle_attendance_log("STG001", rawdata)
+
+        self.assertEqual(mock_frappe.get_doc.call_count, 1)
+        self.assertEqual(mock_frappe.db.commit.call_count, 2)
+
+    @patch("navari_cams_biometric.cams_biometric.controllers.cams_call.frappe")
+    @patch("navari_cams_biometric.cams_biometric.controllers.cams_call.parser")
+    def test_handle_punch_logs_inserts_checkins(self, mock_parser, mock_frappe):
+        punch_logs = [{
+            "Type": "CheckIn",
+            "LogTime": "2024-05-01T08:00:00",
+            "UserID": "EMP001",
+            "InputType": "Fingerprint"
+        }, {
+            "Type": "CheckOut",
+            "LogTime": "2024-05-01T17:00:00",
+            "UserID": "EMP001",
+            "InputType": "Fingerprint"
+        }]
+
+        mock_parser.parse.return_value.strftime.return_value = "2024-05-01 08:00:00"
+        mock_frappe.db.exists.return_value = None
+        mock_frappe.get_doc.return_value.insert.return_value = None
+        mock_frappe.db.commit = MagicMock()
+        mock_frappe.db.sql.return_value = [{"default_shift": "Shift A"}]
+
+        handle_punch_logs("STG001", punch_logs)
+
+        self.assertEqual(mock_frappe.get_doc.call_count, 2)
+        self.assertEqual(mock_frappe.db.commit.call_count, 4)
+
+    @patch("navari_cams_biometric.cams_biometric.controllers.cams_call.frappe")
+    @patch("navari_cams_biometric.cams_biometric.controllers.cams_call.handle_attendance_log")
+    @patch("navari_cams_biometric.cams_biometric.controllers.cams_call.handle_punch_logs")
+    def test_attendance_function(self, mock_handle_punch_logs, mock_handle_attendance_log, mock_frappe):
+        mock_frappe.local.request.get_data.return_value = ''
+        mock_frappe.local.form_dict.get.return_value = None
+
+        response = attendance()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.mimetype, "application/json")
+        self.assertEqual(response.data, b'{"status": "done"}')
+        mock_handle_attendance_log.assert_not_called()
+        mock_handle_punch_logs.assert_not_called()
+
+        mock_frappe.local.request.get_data.return_value = 'invalid json'
+        mock_frappe.local.form_dict.get.return_value = None
+
+        response = attendance()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.mimetype, "application/json")
+        self.assertEqual(response.data, b'{"status": "done"}')
+        mock_handle_attendance_log.assert_not_called()
+        mock_handle_punch_logs.assert_not_called()
+
+        data_realtime = {
+            "RealTime": {
+                "PunchLog": {
+                    "Type": "CheckIn",
+                    "LogTime": "2025-05-29T09:00:00",
+                    "UserId": "EMP001",
+                    "InputType": "Fingerprint"
+                }
+            }
+        }
+        rawdata_realtime = json.dumps(data_realtime)
+        mock_frappe.local.request.get_data.return_value = rawdata_realtime
+        mock_frappe.local.form_dict.get.return_value = "STG001"
+
+        response = attendance()
+        self.assertEqual(response.status_code, 200)
+        mock_handle_attendance_log.assert_called_once_with("STG001", rawdata_realtime)
+
+        data_punchlog = {
+            "PunchLog": {
+                "Log": [{
+                    "Type": "CheckOut",
+                    "LogTime": "2025-05-29T17:00:00",
+                    "UserID": "EMP001",
+                    "InputType": "Fingerprint"
+                }]
+            }
+        }
+        rawdata_punchlog = json.dumps(data_punchlog)
+        mock_frappe.local.request.get_data.return_value = rawdata_punchlog
+        mock_frappe.local.form_dict.get.return_value = "STG001"
+
+        response = attendance()
+        self.assertEqual(response.status_code, 200)
+        mock_handle_punch_logs.assert_called_once_with("STG001", data_punchlog["PunchLog"]["Log"])
+
+

--- a/navari_cams_biometric/cams_biometric/controllers/test_cams_call.py
+++ b/navari_cams_biometric/cams_biometric/controllers/test_cams_call.py
@@ -1,6 +1,9 @@
+from datetime import datetime
 import json
+import frappe
 from frappe.tests.utils import FrappeTestCase
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
+from frappe import db
 from navari_cams_biometric.cams_biometric.controllers.cams_call import (
     handle_attendance_log,
     handle_punch_logs,
@@ -11,11 +14,8 @@ from navari_cams_biometric.cams_biometric.controllers.cams_call import (
 
 class TestCamsCall(FrappeTestCase):
 
-    @patch("navari_cams_biometric.cams_biometric.controllers.cams_call.frappe")
-    @patch("navari_cams_biometric.cams_biometric.controllers.cams_call.parser")
-    def test_handle_attendance_log_inserts_checkin(self, mock_parser, mock_frappe):
-        rawdata = '''
-        {
+    def test_handle_attendance_log_inserts_checkin(self):
+        rawdata = json.dumps({
             "RealTime": {
                 "PunchLog": {
                     "Type": "CheckIn",
@@ -24,70 +24,72 @@ class TestCamsCall(FrappeTestCase):
                     "InputType": "Fingerprint"
                 }
             }
-        }
-        '''
-
-        mock_parser.parse.return_value.strftime.return_value = "2024-05-01 08:00:00"
-        mock_frappe.db.exists.return_value = None
-        mock_frappe.get_doc.return_value.insert.return_value = None
-        mock_frappe.db.commit = MagicMock()
-        mock_frappe.db.sql.return_value = [{"default_shift": "Shift A"}]
+        })
 
         handle_attendance_log("STG001", rawdata)
+        employee_id =  "EMP001"
+        checkins = db.get_all("Employee Checkin", 
+        filters=[
+        ["employee", "=", employee_id],
+        ["time", ">=", "2024-05-01 08:00:00"],
+        ["time", "<", "2024-05-01 09:00:00"]
+         ])
 
-        self.assertEqual(mock_frappe.get_doc.call_count, 1)
-        self.assertEqual(mock_frappe.db.commit.call_count, 2)
 
-    @patch("navari_cams_biometric.cams_biometric.controllers.cams_call.frappe")
-    @patch("navari_cams_biometric.cams_biometric.controllers.cams_call.parser")
-    def test_handle_punch_logs_inserts_checkins(self, mock_parser, mock_frappe):
+        self.assertEqual(len(checkins), 1)
+
+
+    def test_handle_punch_logs_inserts_checkins(self):
         punch_logs = [{
             "Type": "CheckIn",
             "LogTime": "2024-05-01T08:00:00",
-            "UserID": "EMP001",
+            "UserID": "EMP002",
             "InputType": "Fingerprint"
         }, {
             "Type": "CheckOut",
             "LogTime": "2024-05-01T17:00:00",
-            "UserID": "EMP001",
+            "UserID": "EMP002",
             "InputType": "Fingerprint"
         }]
 
-        mock_parser.parse.return_value.strftime.return_value = "2024-05-01 08:00:00"
-        mock_frappe.db.exists.return_value = None
-        mock_frappe.get_doc.return_value.insert.return_value = None
-        mock_frappe.db.commit = MagicMock()
-        mock_frappe.db.sql.return_value = [{"default_shift": "Shift A"}]
 
         handle_punch_logs("STG001", punch_logs)
 
-        self.assertEqual(mock_frappe.get_doc.call_count, 2)
-        self.assertEqual(mock_frappe.db.commit.call_count, 4)
+        employee_id = "EMP002"
+        checkins = db.get_all("Employee Checkin", 
+        filters=[
+        ["employee", "=", employee_id],
+        ["time", ">=", "2024-05-01 08:00:00"],
+        ["time", "<", "2024-05-01 18:00:00"]
+         ])
 
-    @patch("navari_cams_biometric.cams_biometric.controllers.cams_call.frappe")
-    @patch("navari_cams_biometric.cams_biometric.controllers.cams_call.handle_attendance_log")
+        self.assertEqual(len(checkins), 2)
+
     @patch("navari_cams_biometric.cams_biometric.controllers.cams_call.handle_punch_logs")
-    def test_attendance_function(self, mock_handle_punch_logs, mock_handle_attendance_log, mock_frappe):
-        mock_frappe.local.request.get_data.return_value = ''
+    @patch("navari_cams_biometric.cams_biometric.controllers.cams_call.handle_attendance_log")
+    @patch("navari_cams_biometric.cams_biometric.controllers.cams_call.frappe")
+    def test_attendance_function(
+        self,
+        mock_frappe,
+        mock_handle_attendance_log,
+        mock_handle_punch_logs
+    ):
+        # Case 1: No rawdata
+        mock_frappe.local.request.get_data.return_value = None
         mock_frappe.local.form_dict.get.return_value = None
 
         response = attendance()
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.mimetype, "application/json")
         self.assertEqual(response.data, b'{"status": "done"}')
-        mock_handle_attendance_log.assert_not_called()
-        mock_handle_punch_logs.assert_not_called()
 
-        mock_frappe.local.request.get_data.return_value = 'invalid json'
-        mock_frappe.local.form_dict.get.return_value = None
-
+        # Case 2: Invalid JSON
+        mock_frappe.local.request.get_data.return_value = "invalid json"
         response = attendance()
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.mimetype, "application/json")
         self.assertEqual(response.data, b'{"status": "done"}')
-        mock_handle_attendance_log.assert_not_called()
-        mock_handle_punch_logs.assert_not_called()
 
+        # Case 3: RealTime CheckIn
         data_realtime = {
             "RealTime": {
                 "PunchLog": {
@@ -106,6 +108,7 @@ class TestCamsCall(FrappeTestCase):
         self.assertEqual(response.status_code, 200)
         mock_handle_attendance_log.assert_called_once_with("STG001", rawdata_realtime)
 
+        # Case 4: PunchLog CheckOut
         data_punchlog = {
             "PunchLog": {
                 "Log": [{
@@ -124,18 +127,25 @@ class TestCamsCall(FrappeTestCase):
         self.assertEqual(response.status_code, 200)
         mock_handle_punch_logs.assert_called_once_with("STG001", data_punchlog["PunchLog"]["Log"])
 
-    @patch("navari_cams_biometric.cams_biometric.controllers.cams_call.frappe")
-    def test_update_last_sync_time_calls_db_methods(self, mock_frappe):
-        shift = "Shift A"
-        time = "2024-05-01 08:00:00"
+    def test_update_last_sync_time_updates_field(self):
+        if frappe.db.exists("Shift Type", "TEST_SHIFT"):
+            frappe.delete_doc("Shift Type", "TEST_SHIFT", force=True)
+            
+        #dummy Shift Type
+        shift_doc = frappe.get_doc({
+            "doctype": "Shift Type",
+            "name": "TEST_SHIFT",
+            "start_time": "09:00:00",
+            "end_time": "17:00:00"
+        }).insert()
 
-        mock_frappe.db.set_value = MagicMock()
-        mock_frappe.db.commit = MagicMock()
+        
+        test_time = datetime(2024, 6, 6, 10, 30)
 
-        result = update_last_sync_time(shift, time)
+        
+        result = update_last_sync_time(shift_doc.name, test_time)
 
-        mock_frappe.db.set_value.assert_called_once_with(
-            "Shift Type", shift, "last_sync_of_checkin", time, update_modified=False
-        )
-        mock_frappe.db.commit.assert_called_once()
+        updated_shift = frappe.get_doc("Shift Type", shift_doc.name)
+
         self.assertEqual(result, "done")
+        self.assertEqual(updated_shift.last_sync_of_checkin, test_time)


### PR DESCRIPTION
- Added tests for the `attendance` function covering:
  empty request body,
   invalid JSON input,
  processing RealTime attendance logs,
  processing PunchLog entries,
- Mocked dependencies to isolate the endpoint logic
- Ensured proper calls to `handle_attendance_log` and `handle_punch_logs`
- Verified correct HTTP response for all cases